### PR TITLE
feat: add multi-theme support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,10 @@ const withMDX = createMDX({
         "rehype-pretty-code",
         {
           keepBackground: false,
-          theme: "synthwave-84",
+          theme: {
+            light: "github-light",
+            dark: "synthwave-84",
+          },
         },
       ],
       [

--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -147,7 +147,9 @@ const CVPage = async ({
           </ul>
         </section>
         <section>
-          <h2 className={typefaceHeading2()}>Executive Summary</h2>
+          <h2 className={typefaceHeading2("border-b pb-1")}>
+            Executive Summary
+          </h2>
           <p className={typefaceBody("mt-2")}>
             Multidisciplinary Fullstack Engineer with 6+ years of experience
             building award-winning, data-rich web applications for public sector
@@ -171,7 +173,9 @@ const CVPage = async ({
           </ul>
         </section>
         <section>
-          <h2 className={typefaceHeading2()}>Technical Skills</h2>
+          <h2 className={typefaceHeading2("border-b pb-1")}>
+            Technical Skills
+          </h2>
 
           <ul className={typefaceBody()}>
             <li className="my-2">
@@ -193,7 +197,7 @@ const CVPage = async ({
           </ul>
         </section>
         <section>
-          <h2 className={typefaceHeading2()}>Experience</h2>
+          <h2 className={typefaceHeading2("border-b pb-1")}>Experience</h2>
           {mode === "edit" && formOptions ? (
             <CvSectionEditable
               occupations={A.map(workExperience, serialize)}
@@ -211,7 +215,7 @@ const CVPage = async ({
           )}
         </section>
         <section>
-          <h2 className={typefaceHeading2()}>Key Projects</h2>
+          <h2 className={typefaceHeading2("border-b pb-1")}>Key Projects</h2>
           <ul className={typefaceBody()}>
             {projects.map((project) => (
               <li className="my-4" key={project.id}>
@@ -227,7 +231,7 @@ const CVPage = async ({
           </ul>
         </section>
         <section>
-          <h2 className={typefaceHeading2()}>Education</h2>
+          <h2 className={typefaceHeading2("border-b pb-1")}>Education</h2>
           {mode === "edit" && formOptions ? (
             <CvSectionEditable
               occupations={A.map(education, serialize)}
@@ -247,7 +251,9 @@ const CVPage = async ({
           )}
         </section>
         <section>
-          <h2 className={typefaceHeading2()}>Community & Volunteering</h2>
+          <h2 className={typefaceHeading2("border-b pb-1")}>
+            Community & Volunteering
+          </h2>
           {mode === "edit" && formOptions ? (
             <CvSectionEditable
               occupations={A.map(volunteering, serialize)}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { Footer } from "@/components/organism/footer";
 import { Navbar } from "@/components/organism/navbar";
 import { siteMetadata } from "@/lib/metadata";
 import { cn } from "@/lib/utils";
+import { PaletteProvider } from "@/providers/palette-provider";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteMetadata.siteUrl),
@@ -61,6 +62,11 @@ export default function RootLayout({
       className={`${roboto_mono.variable} ${josefin_sans.variable} ${fira_mono.variable}`}
       suppressHydrationWarning
     >
+      <head>
+        <Script id="palette-init" strategy="beforeInteractive">
+          {`(function(){try{var p=localStorage.getItem("palette");if(p&&p!=="standard")document.documentElement.dataset.theme=p}catch(e){}})()`}
+        </Script>
+      </head>
       <Script
         defer
         src="https://umami.lloydrichards.dev/script.js"
@@ -68,19 +74,21 @@ export default function RootLayout({
       />
       <body className={cn("min-h-dvh w-full")} suppressHydrationWarning>
         <ThemeProvider attribute="class" enableSystem>
-          <TooltipProvider>
-            <div
-              className={cn(
-                "min-h-dvh w-full lg:max-w-6xl",
-                "mosaic-columns grid grid-flow-dense",
-                "mx-auto p-2",
-              )}
-            >
-              <Navbar />
-              {children}
-              <Footer />
-            </div>
-          </TooltipProvider>
+          <PaletteProvider>
+            <TooltipProvider>
+              <div
+                className={cn(
+                  "min-h-dvh w-full lg:max-w-6xl",
+                  "mosaic-columns grid grid-flow-dense",
+                  "mx-auto p-2",
+                )}
+              >
+                <Navbar />
+                {children}
+                <Footer />
+              </div>
+            </TooltipProvider>
+          </PaletteProvider>
         </ThemeProvider>
         <Analytics />
         <SpeedInsights />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,14 @@
 import { Effect, Option, Schema } from "effect";
-import { Briefcase, FlaskConical, Star } from "lucide-react";
+import { Briefcase, FlaskConical, GitBranch, Star } from "lucide-react";
 import { ExpandableTile } from "@/components/atom/expandable-tile";
 import { Tile } from "@/components/atom/tile";
 import { TileExpandButton } from "@/components/atom/tile-expand-button";
-import SvgGithub from "@/components/icons/github";
 import { GitHubCommitCard } from "@/components/molecule/github_commit_card";
-import { KPICard } from "@/components/molecule/kpi_card";
+import { KPIStrip } from "@/components/molecule/kpi_strip";
 import { LabCard } from "@/components/molecule/lab_card";
 import { ProjectCard } from "@/components/molecule/project_card";
 import { SkillCard } from "@/components/molecule/skill_card";
-import { ThemeToggle } from "@/components/molecule/theme-toggle";
+import { ThemeSwitcherTile } from "@/components/molecule/theme-switcher-tile";
 import { Logo } from "@/components/organism/logo";
 import { PersonJsonLd } from "@/components/organism/person-jsonld";
 import { SkillBarChart } from "@/components/organism/skill_bar_chart/skill_bar_chart.server";
@@ -75,65 +74,58 @@ const HomePage = async () => {
       <PersonJsonLd />
       <Mosaic>
         <Tile
-          size="square-md"
-          className="bg-background overflow-clip group grid items-center"
+          size="unset"
+          className="col-span-4 row-span-4 md:col-span-4 md:row-span-5 lg:col-span-6 lg:row-span-6 bg-background overflow-clip group flex justify-center items-center"
         >
           <Logo className="text-primary scale-110 transition-transform hover:scale-115" />
         </Tile>
+        {/* Compact stat strip */}
+        <Tile size="full-xs">
+          <KPIStrip
+            stats={[
+              {
+                label: "Projects",
+                value: allPortfolioProjects.length,
+                icon: <Briefcase className="size-full" />,
+              },
+              {
+                label: "Labs",
+                value: allLabs.length,
+                icon: <FlaskConical className="size-full" />,
+              },
+              {
+                label: "Repos",
+                value: githubStats.repos,
+                icon: <GitBranch className="size-full" />,
+              },
+              {
+                label: "Stars",
+                value: githubStats.stars,
+                icon: <Star className="size-full" />,
+              },
+            ]}
+          />
+        </Tile>
         <Tile
           size="unset"
-          className="col-span-full row-span-1 grid items-center px-8 md:col-span-12 md:row-span-2 lg:col-span-16 lg:row-span-2"
+          className="col-span-full row-span-1 grid items-end px-4 pb-1 md:col-span-12 md:row-span-2 md:px-8 lg:col-span-18 lg:row-span-2"
         >
           <h1 className={typefaceHeading1("mt-0")}>Hello, I&apos;m Lloyd</h1>
         </Tile>
         <Tile
           size="unset"
-          className="col-span-full row-span-4 grid items-center p-4 md:col-span-12 lg:col-span-18 lg:row-span-4"
+          className="col-span-full row-span-3 grid items-start p-4 md:col-span-12 md:row-span-3 lg:col-span-18 lg:row-span-4"
         >
           <p className={typefaceBody()}>
-            This website is a personal portfolio and lab space where I can
-            showcase my projects, experiment with new ideas, and share my
-            thoughts and experiences through blogging. Please feel free to
-            explore my recent projects, read my lab and blog posts, or connect
-            with me through social media.
+            Interaction engineer, building award-winning data platforms and
+            interactive visualizations. This site runs on three complete themes
+            to prove the system works.
           </p>
         </Tile>
 
-        {/* KPI Cards Section - Grouped together for better visual cohesion */}
-        <Tile size="box-sm">
-          <KPICard
-            label="Projects"
-            value={allPortfolioProjects.length}
-            subtitle="Total Articles"
-            icon={<Briefcase className="size-5" />}
-          />
-        </Tile>
-
-        <Tile size="box-sm">
-          <KPICard
-            label="Labs"
-            value={allLabs.length}
-            subtitle="Total Published"
-            icon={<FlaskConical className="size-5" />}
-          />
-        </Tile>
-
-        <Tile size="box-sm">
-          <KPICard
-            label="Github"
-            value={githubStats.repos}
-            subtitle="Total Repos"
-            icon={<SvgGithub className="size-5" />}
-          />
-        </Tile>
-
-        <Tile size="box-sm">
-          <KPICard
-            label="GitHub"
-            value={githubStats.stars}
-            subtitle="Total Stars"
-            icon={<Star className="size-5" />}
-          />
+        {/* Theme Switcher Tile */}
+        <Tile size="square-md">
+          <ThemeSwitcherTile />
         </Tile>
 
         {/* Projects Section */}

--- a/src/components/atom/ansi-terminal.tsx
+++ b/src/components/atom/ansi-terminal.tsx
@@ -36,24 +36,26 @@ export const AnsiTerminal = ({
 }: AnsiTerminalProps) => (
   <div
     className={cn(
-      "my-6 overflow-hidden rounded-md border border-border shadow-lg bg-[#232131]",
+      "my-6 overflow-hidden rounded-md border border-border",
       className,
     )}
   >
     {/* Title bar */}
-    <div className="flex items-center gap-2 bg-code px-3 py-2 border-b border-border">
+    <div className="flex items-center gap-2 bg-muted/50 px-3 py-2 border-b border-border/50">
       <div className="flex gap-1.5">
-        <span className="size-3 rounded-full bg-[#FF5F56]" />
-        <span className="size-3 rounded-full bg-[#FFBD2E]" />
-        <span className="size-3 rounded-full bg-[#27C93F]" />
+        <span className="size-2.5 rounded-full bg-[#FF5F56]" />
+        <span className="size-2.5 rounded-full bg-[#FFBD2E]" />
+        <span className="size-2.5 rounded-full bg-[#27C93F]" />
       </div>
       {title && (
-        <span className="ml-2 text-xs text-muted-foreground">{title}</span>
+        <span className="ml-2 text-xs font-medium text-muted-foreground">
+          {title}
+        </span>
       )}
     </div>
-    {/* Terminal body */}
+    {/* Terminal body — dark background required for ANSI color legibility */}
     <pre
-      className="overflow-x-auto bg-code p-4 text-sm leading-[1.3] text-code-foreground"
+      className="overflow-x-auto bg-[hsl(220_20%_12%)] p-4 text-sm leading-[1.3] text-slate-200"
       style={{
         ...vscodePalette,
         fontFamily:

--- a/src/components/atom/tile.variants.ts
+++ b/src/components/atom/tile.variants.ts
@@ -12,6 +12,8 @@ export const tileVariants = cva("bg-card relative rounded-md", {
         "col-span-2 row-span-2 md:col-span-4 md:row-span-3 lg:col-span-6 lg:row-span-4",
       "box-md":
         "col-span-8 row-span-4 md:col-span-8 md:row-span-4 lg:col-span-12 lg:row-span-6",
+      "full-xs":
+        "col-span-full row-span-1 md:col-span-full md:row-span-1 lg:col-span-full lg:row-span-1",
       "full-sm":
         "col-span-full row-span-3 md:col-span-full md:row-span-4 lg:col-span-full lg:row-span-4",
       "full-md":

--- a/src/components/molecule/kpi_strip.tsx
+++ b/src/components/molecule/kpi_strip.tsx
@@ -1,0 +1,48 @@
+import { Briefcase, FlaskConical, GitBranch, Star } from "lucide-react";
+import type { FC } from "react";
+import { typefaceMeta } from "@/components/tokens/typeface";
+import { cn } from "@/lib/utils";
+
+type StatItem = {
+  label: string;
+  value: number;
+  icon: React.ReactNode;
+};
+
+type KPIStripProps = {
+  stats: StatItem[];
+  className?: string;
+};
+
+/**
+ * Compact horizontal stat strip. Replaces 4 separate KPI tiles
+ * with a single row that communicates the same data in less space.
+ */
+export const KPIStrip: FC<KPIStripProps> = ({ stats, className }) => {
+  return (
+    <div
+      className={cn(
+        "flex h-full items-center justify-between gap-2 px-3 md:gap-4 md:px-4",
+        className,
+      )}
+    >
+      {stats.map((stat) => (
+        <div key={stat.label} className="flex items-center gap-1.5 md:gap-2">
+          <span className="text-muted-foreground/60 size-3.5 md:size-4">
+            {stat.icon}
+          </span>
+          <span className="font-mono text-base font-semibold tabular-nums md:text-lg">
+            {stat.value}
+          </span>
+          <span
+            className={typefaceMeta(
+              "text-muted-foreground hidden text-xs sm:inline",
+            )}
+          >
+            {stat.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/molecule/mermaid.tsx
+++ b/src/components/molecule/mermaid.tsx
@@ -12,7 +12,7 @@ export const Mermaid: React.FC<MermaidProps> = ({ ...props }) => {
     <MdxMermaid
       config={{
         theme: {
-          light: "dark",
+          light: "neutral",
           dark: "dark",
         },
       }}

--- a/src/components/molecule/palette-toggle.tsx
+++ b/src/components/molecule/palette-toggle.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { HexagonIcon, PenToolIcon, TerminalIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import { cn } from "@/lib/utils";
 import {
-  type Palette,
   PALETTES,
+  type Palette,
   usePalette,
 } from "@/providers/palette-provider";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../atom/tooltip";
@@ -21,6 +22,9 @@ const PALETTE_META: Record<
 
 export const PaletteToggle = ({ className }: { className?: string }) => {
   const { palette, setPalette } = usePalette();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
 
   const cyclePalette = () => {
     const currentIndex = PALETTES.indexOf(palette);
@@ -28,7 +32,10 @@ export const PaletteToggle = ({ className }: { className?: string }) => {
     setPalette(PALETTES[nextIndex]);
   };
 
-  const nextPalette = PALETTES[(PALETTES.indexOf(palette) + 1) % PALETTES.length];
+  // Use "standard" during SSR/hydration to match server render
+  const activePalette = mounted ? palette : "standard";
+  const nextPalette =
+    PALETTES[(PALETTES.indexOf(activePalette) + 1) % PALETTES.length];
 
   return (
     <Tooltip>
@@ -46,7 +53,7 @@ export const PaletteToggle = ({ className }: { className?: string }) => {
       >
         {PALETTES.map((p) => {
           const { icon: Icon } = PALETTE_META[p];
-          const isActive = palette === p;
+          const isActive = activePalette === p;
           return (
             <Icon
               key={p}

--- a/src/components/molecule/palette-toggle.tsx
+++ b/src/components/molecule/palette-toggle.tsx
@@ -1,17 +1,34 @@
 "use client";
 
-import { HexagonIcon, TerminalIcon } from "lucide-react";
+import { HexagonIcon, PenToolIcon, TerminalIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { usePalette } from "@/providers/palette-provider";
+import {
+  type Palette,
+  PALETTES,
+  usePalette,
+} from "@/providers/palette-provider";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../atom/tooltip";
+
+const PALETTE_META: Record<
+  Palette,
+  { icon: typeof HexagonIcon; label: string }
+> = {
+  standard: { icon: HexagonIcon, label: "standard" },
+  nerdy: { icon: TerminalIcon, label: "nerdy" },
+  analog: { icon: PenToolIcon, label: "analog" },
+};
 
 export const PaletteToggle = ({ className }: { className?: string }) => {
   const { palette, setPalette } = usePalette();
 
-  const togglePalette = () => {
-    setPalette(palette === "standard" ? "nerdy" : "standard");
+  const cyclePalette = () => {
+    const currentIndex = PALETTES.indexOf(palette);
+    const nextIndex = (currentIndex + 1) % PALETTES.length;
+    setPalette(PALETTES[nextIndex]);
   };
+
+  const nextPalette = PALETTES[(PALETTES.indexOf(palette) + 1) % PALETTES.length];
 
   return (
     <Tooltip>
@@ -23,16 +40,29 @@ export const PaletteToggle = ({ className }: { className?: string }) => {
               "size-full p-0 inline-flex items-center justify-center rounded-md focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none",
               className,
             )}
-            onClick={() => togglePalette()}
+            onClick={() => cyclePalette()}
           />
         }
       >
-        <HexagonIcon className="size-[1.2rem] scale-100 rotate-0 transition-all [[data-theme=nerdy]_&]:scale-0 [[data-theme=nerdy]_&]:-rotate-90" />
-        <TerminalIcon className="absolute size-[1.2rem] scale-0 rotate-90 transition-all [[data-theme=nerdy]_&]:scale-100 [[data-theme=nerdy]_&]:rotate-0" />
+        {PALETTES.map((p) => {
+          const { icon: Icon } = PALETTE_META[p];
+          const isActive = palette === p;
+          return (
+            <Icon
+              key={p}
+              className={cn(
+                "size-[1.2rem] transition-all duration-300 absolute",
+                isActive
+                  ? "scale-100 rotate-0 opacity-100"
+                  : "scale-0 rotate-90 opacity-0",
+              )}
+            />
+          );
+        })}
         <span className="sr-only">Toggle palette</span>
       </TooltipTrigger>
       <TooltipContent side="bottom">
-        Switch to {palette === "standard" ? "nerdy" : "standard"} palette
+        Switch to {nextPalette} palette
       </TooltipContent>
     </Tooltip>
   );

--- a/src/components/molecule/palette-toggle.tsx
+++ b/src/components/molecule/palette-toggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { HexagonIcon, TerminalIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { usePalette } from "@/providers/palette-provider";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../atom/tooltip";
+
+export const PaletteToggle = ({ className }: { className?: string }) => {
+  const { palette, setPalette } = usePalette();
+
+  const togglePalette = () => {
+    setPalette(palette === "standard" ? "nerdy" : "standard");
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            className={cn(
+              "size-full p-0 inline-flex items-center justify-center rounded-md focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none",
+              className,
+            )}
+            onClick={() => togglePalette()}
+          />
+        }
+      >
+        <HexagonIcon className="size-[1.2rem] scale-100 rotate-0 transition-all [[data-theme=nerdy]_&]:scale-0 [[data-theme=nerdy]_&]:-rotate-90" />
+        <TerminalIcon className="absolute size-[1.2rem] scale-0 rotate-90 transition-all [[data-theme=nerdy]_&]:scale-100 [[data-theme=nerdy]_&]:rotate-0" />
+        <span className="sr-only">Toggle palette</span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        Switch to {palette === "standard" ? "nerdy" : "standard"} palette
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/src/components/molecule/theme-switcher-tile.tsx
+++ b/src/components/molecule/theme-switcher-tile.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { Loader2Icon, MoonIcon, SunIcon } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import {
+  PALETTES,
+  type Palette,
+  usePalette,
+} from "@/providers/palette-provider";
+import { typefaceMeta } from "../tokens/typeface";
+
+const PALETTE_LABELS: Record<Palette, string> = {
+  standard: "Standard",
+  nerdy: "Nerdy",
+  analog: "Analog",
+};
+
+/**
+ * A mosaic tile showing all 6 theme combinations (3 palettes x 2 modes)
+ * with direct selection. Each cell is a miniature swatch previewing the
+ * palette's background, card, primary, and secondary colors.
+ */
+export const ThemeSwitcherTile = ({ className }: { className?: string }) => {
+  const { palette, setPalette } = usePalette();
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <div
+        className={cn(
+          "flex h-full flex-col items-center justify-center",
+          className,
+        )}
+      >
+        <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const modes = ["light", "dark"] as const;
+
+  return (
+    <div className={cn("flex h-full flex-col", className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between px-2 pt-1.5 pb-0.5 md:px-3 md:pt-2 md:pb-1">
+        <p
+          className={typefaceMeta(
+            "text-muted-foreground text-[10px] uppercase md:text-xs",
+          )}
+        >
+          Theme
+        </p>
+      </div>
+
+      {/* Grid: 3 columns (palettes) x 2 rows (modes) */}
+      <div className="grid flex-1 grid-cols-3 grid-rows-2 gap-1 p-1.5 md:gap-1.5 md:p-2">
+        {modes.map((mode) =>
+          PALETTES.map((p) => {
+            const isActive = palette === p && theme === mode;
+            return (
+              <button
+                key={`${p}-${mode}`}
+                type="button"
+                onClick={() => {
+                  setPalette(p);
+                  setTheme(mode);
+                }}
+                aria-label={`${PALETTE_LABELS[p]} ${mode}`}
+                aria-pressed={isActive}
+                className={cn(
+                  "group relative flex flex-col items-center justify-center gap-0.5 rounded-sm border transition-colors duration-150 md:gap-1",
+                  "focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none",
+                  isActive
+                    ? "border-primary bg-accent"
+                    : "border-border/50 hover:border-border hover:bg-muted/50",
+                )}
+              >
+                {/* Swatch: 4 dots representing bg, card, primary, secondary */}
+                <SwatchPreview palette={p} mode={mode} />
+                {/* Label (only on first row) */}
+                {mode === "light" && (
+                  <span
+                    className={typefaceMeta(
+                      "text-muted-foreground hidden text-[10px] leading-none md:block",
+                    )}
+                  >
+                    {PALETTE_LABELS[p]}
+                  </span>
+                )}
+              </button>
+            );
+          }),
+        )}
+      </div>
+
+      {/* Mode indicators */}
+      <div className="grid grid-cols-2 gap-1 px-1.5 pb-1.5 md:gap-1.5 md:px-2 md:pb-2">
+        {modes.map((mode) => (
+          <div
+            key={mode}
+            className="flex items-center justify-center gap-1 py-0.5"
+          >
+            {mode === "light" ? (
+              <SunIcon className="size-2.5 text-muted-foreground md:size-3" />
+            ) : (
+              <MoonIcon className="size-2.5 text-muted-foreground md:size-3" />
+            )}
+            <span
+              className={typefaceMeta(
+                "text-muted-foreground text-[9px] md:text-[10px]",
+              )}
+            >
+              {mode}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Renders a 2x2 dot grid previewing a palette's characteristic colors.
+ * Uses hardcoded representative values from each theme's CSS to give
+ * an honest preview without needing to parse computed styles.
+ */
+function SwatchPreview({
+  palette,
+  mode,
+}: {
+  palette: Palette;
+  mode: "light" | "dark";
+}) {
+  const colors = SWATCH_COLORS[palette][mode];
+  return (
+    <div className="grid grid-cols-2 gap-0.5">
+      {colors.map((color, i) => (
+        <div
+          key={i}
+          className={cn(
+            "size-2.5 rounded-full md:size-3",
+            mode === "light" && i < 2 && "ring-1 ring-border/30",
+          )}
+          style={{ backgroundColor: color }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Representative colors for each palette + mode combination.
+ * Order: [background, card, primary, secondary]
+ * Pulled directly from the CSS theme files.
+ */
+const SWATCH_COLORS: Record<
+  Palette,
+  Record<"light" | "dark", [string, string, string, string]>
+> = {
+  standard: {
+    light: [
+      "hsl(210 40% 98%)", // bg: mono-050
+      "hsl(210 40% 96.1%)", // card: mono-100
+      "hsl(162.9 93.5% 24.3%)", // primary-700
+      "hsl(37.7 92.1% 50.2%)", // secondary-500
+    ],
+    dark: [
+      "hsl(222.2 47.4% 11.2%)", // bg: mono-900
+      "hsl(217.2 32.6% 17.5%)", // card: mono-800
+      "hsl(160.1 84.1% 39.4%)", // primary-500
+      "hsl(37.7 92.1% 50.2%)", // secondary-500
+    ],
+  },
+  nerdy: {
+    light: [
+      "hsl(80 20% 97%)", // bg: mono-050
+      "hsl(75 15% 93%)", // card: mono-100
+      "hsl(142 60% 30%)", // primary-600
+      "hsl(280 40% 48%)", // secondary-500
+    ],
+    dark: [
+      "hsl(110 22% 5%)", // bg: mono-950
+      "hsl(105 18% 9%)", // card: mono-900
+      "hsl(138 42% 48%)", // primary-400
+      "hsl(278 35% 58%)", // secondary-400
+    ],
+  },
+  analog: {
+    light: [
+      "hsl(40 30% 97%)", // bg: mono-050
+      "hsl(38 28% 93%)", // card: mono-100
+      "hsl(6 60% 36%)", // primary-600
+      "hsl(220 38% 42%)", // secondary-500
+    ],
+    dark: [
+      "hsl(22 26% 11%)", // bg: mono-900
+      "hsl(24 22% 16%)", // card: mono-800
+      "hsl(10 52% 52%)", // primary-400
+      "hsl(222 30% 52%)", // secondary-400
+    ],
+  },
+};

--- a/src/components/molecule/theme-toggle.tsx
+++ b/src/components/molecule/theme-toggle.tsx
@@ -29,7 +29,7 @@ export const ThemeToggle = ({ className }: { className?: string }) => {
         <MoonIcon className="absolute size-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
         <span className="sr-only">Toggle theme</span>
       </TooltipTrigger>
-      <TooltipContent side="right">
+      <TooltipContent side="bottom">
         Toggle between light and dark theme
       </TooltipContent>
     </Tooltip>

--- a/src/components/organism/navbar.tsx
+++ b/src/components/organism/navbar.tsx
@@ -32,7 +32,7 @@ export const Navbar: React.FC = () => {
       <Link
         href="/"
         className={typefaceHeading3(
-          "col-span-3 mt-0 overflow-clip md:col-span-6 lg:col-span-6",
+          "text-lg flex items-center md:text-2xl col-span-2 mt-0 overflow-clip md:col-span-6 lg:col-span-6",
         )}
       >
         lloydrichards.dev

--- a/src/components/organism/navbar.tsx
+++ b/src/components/organism/navbar.tsx
@@ -4,6 +4,7 @@ import { typefaceHeading3 } from "@/components/tokens/typeface";
 import { cn } from "@/lib/utils";
 import { navigationMenuTriggerStyle } from "../atom/navigation-menu";
 import { tileVariants } from "../atom/tile.variants";
+import { PaletteToggle } from "../molecule/palette-toggle";
 import { ThemeToggle } from "../molecule/theme-toggle";
 
 export const Navbar: React.FC = () => {
@@ -49,6 +50,7 @@ export const Navbar: React.FC = () => {
           <span className="hidden md:block">{route.label}</span>
         </Link>
       ))}
+      <PaletteToggle className={tileVariants({ size: "unset" })} />
       <ThemeToggle className={tileVariants({ size: "unset" })} />
     </header>
   );

--- a/src/components/organism/person-jsonld.tsx
+++ b/src/components/organism/person-jsonld.tsx
@@ -34,11 +34,5 @@ export const PersonJsonLd = () => {
     },
   };
 
-  return (
-    <script
-      type="application/ld+json"
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD script for SEO
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-    />
-  );
+  return <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>;
 };

--- a/src/components/tokens/prose_components.tsx
+++ b/src/components/tokens/prose_components.tsx
@@ -31,7 +31,7 @@ export const proseComponents = {
     <h2
       className={cn(
         typefaceHeading2(),
-        "mt-10 scroll-m-20 first:mt-0",
+        "border-b pb-1 mt-10 scroll-m-20 first:mt-0",
         className,
       )}
       {...props}
@@ -162,21 +162,31 @@ export const proseComponents = {
   pre: ({ className, ...props }: React.HTMLAttributes<HTMLPreElement>) => (
     <pre
       className={cn(
-        "bg-code text-code-foreground mb-4 overflow-x-auto rounded-md p-3 font-mono",
+        "bg-muted/50 text-foreground mb-4 overflow-x-auto rounded-md border border-border p-4 font-mono text-sm leading-relaxed",
         className,
       )}
       {...props}
     />
   ),
-  code: ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
-    <code
-      className={cn(
-        "bg-code text-code-foreground px-1 font-mono text-sm",
-        className,
-      )}
-      {...props}
-    />
-  ),
+  code: ({
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLElement> & { "data-theme"?: string }) => {
+    // Code inside pre (from rehype-pretty-code) should not get inline pill styling
+    const isBlock = "data-theme" in props || "data-language" in props;
+    if (isBlock) {
+      return <code className={cn("font-mono text-sm", className)} {...props} />;
+    }
+    return (
+      <code
+        className={cn(
+          "bg-muted text-foreground rounded-sm px-1.5 py-0.5 font-mono text-[0.85em]",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
   figure: ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
     <figure className={cn("my-6", className)} {...props} />
   ),

--- a/src/components/tokens/typeface.tsx
+++ b/src/components/tokens/typeface.tsx
@@ -1,18 +1,14 @@
 import { cn } from "@/lib/utils";
 
 // Core Typefaces
-
-// export const typefaceDisplay1 = (className?: string) =>
-//   cn("text-9xl leading-normal font-normal", className);
-
-// export const typefaceDisplay2 = (className?: string) =>
-//   cn("text-8xl leading-normal font-normal", className);
+// Font-family is inherited from the global theme (font-sans = Roboto Mono).
+// Theme variants (e.g. nerdy) override via CSS custom properties.
 
 export const typefaceHeading1 = (className?: string) =>
   cn("text-4xl font-bold tracking-tight", className);
 
 export const typefaceHeading2 = (className?: string) =>
-  cn("border-b pb-1 text-3xl font-semibold tracking-tight", className);
+  cn("text-3xl font-semibold tracking-tight", className);
 
 export const typefaceHeading3 = (className?: string) =>
   cn("text-2xl font-semibold tracking-tight", className);
@@ -21,26 +17,18 @@ export const typefaceHeading4 = (className?: string) =>
   cn("text-xl font-semibold tracking-tight", className);
 
 export const typefaceHeading5 = (className?: string) =>
-  cn("text-lg font-semibold tracking-tight", className);
+  cn("text-lg font-medium tracking-normal", className);
 
 export const typefaceHeading6 = (className?: string) =>
-  cn("text-base font-semibold tracking-tight", className);
+  cn("text-base font-medium tracking-normal", className);
 
-export const typefaceBody = (className?: string) => cn("leading-7", className);
+export const typefaceBody = (className?: string) =>
+  cn("text-base leading-7", className);
 
 export const typefaceMeta = (className?: string) =>
-  cn("text-sm font-normal", className);
+  cn("text-sm font-normal leading-normal", className);
 
 // Component Typefaces
 
 export const typefaceAnchor = (className?: string) =>
   cn("font-medium underline underline-offset-4", className);
-
-// export const typefaceValue1 = (className?: string) =>
-//   cn("text-3xl font-normal", "leading-none", className);
-
-// export const typefaceValue2 = (className?: string) =>
-//   cn("text-2xl font-normal", "leading-none", className);
-
-// export const typefaceValue3 = (className?: string) =>
-//   cn("text-lg font-normal", "leading-none", className);

--- a/src/providers/palette-provider.tsx
+++ b/src/providers/palette-provider.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+export const PALETTES = ["standard", "nerdy"] as const;
+export type Palette = (typeof PALETTES)[number];
+
+const STORAGE_KEY = "palette";
+const DEFAULT_PALETTE: Palette = "standard";
+
+interface PaletteContextValue {
+  palette: Palette;
+  setPalette: (palette: Palette) => void;
+  palettes: readonly Palette[];
+}
+
+const PaletteContext = createContext<PaletteContextValue | undefined>(
+  undefined,
+);
+
+function disableTransitions() {
+  const style = document.createElement("style");
+  style.setAttribute("data-palette-transition", "");
+  style.textContent = "*, *::before, *::after { transition: none !important; }";
+  document.head.appendChild(style);
+
+  // Force reflow so the style takes effect before any attribute change
+  window.getComputedStyle(document.body).opacity;
+
+  return () => {
+    // Re-enable transitions after one frame
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        style.remove();
+      });
+    });
+  };
+}
+
+function applyPalette(palette: Palette) {
+  if (palette === DEFAULT_PALETTE) {
+    delete document.documentElement.dataset.theme;
+  } else {
+    document.documentElement.dataset.theme = palette;
+  }
+}
+
+export function PaletteProvider({ children }: { children: React.ReactNode }) {
+  const [palette, setPaletteState] = useState<Palette>(() => {
+    if (typeof window === "undefined") return DEFAULT_PALETTE;
+    const stored = localStorage.getItem(STORAGE_KEY) as Palette | null;
+    return stored && PALETTES.includes(stored) ? stored : DEFAULT_PALETTE;
+  });
+
+  const setPalette = useCallback((next: Palette) => {
+    const enableTransitions = disableTransitions();
+    setPaletteState(next);
+    applyPalette(next);
+
+    try {
+      if (next === DEFAULT_PALETTE) {
+        localStorage.removeItem(STORAGE_KEY);
+      } else {
+        localStorage.setItem(STORAGE_KEY, next);
+      }
+    } catch {}
+
+    enableTransitions();
+  }, []);
+
+  // Sync attribute on mount (covers hydration mismatch edge case)
+  useEffect(() => {
+    applyPalette(palette);
+  }, [palette]);
+
+  const value = useMemo<PaletteContextValue>(
+    () => ({ palette, setPalette, palettes: PALETTES }),
+    [palette, setPalette],
+  );
+
+  return (
+    <PaletteContext.Provider value={value}>{children}</PaletteContext.Provider>
+  );
+}
+
+export function usePalette(): PaletteContextValue {
+  const context = useContext(PaletteContext);
+  if (!context) {
+    throw new Error("usePalette must be used within a PaletteProvider");
+  }
+  return context;
+}

--- a/src/providers/palette-provider.tsx
+++ b/src/providers/palette-provider.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 
-export const PALETTES = ["standard", "nerdy"] as const;
+export const PALETTES = ["standard", "nerdy", "analog"] as const;
 export type Palette = (typeof PALETTES)[number];
 
 const STORAGE_KEY = "palette";
@@ -60,9 +60,12 @@ export function PaletteProvider({ children }: { children: React.ReactNode }) {
   });
 
   const setPalette = useCallback((next: Palette) => {
+    // Disable transitions during palette swap to prevent intermediate
+    // blended color states (palette changes swap many variables at once).
     const enableTransitions = disableTransitions();
     setPaletteState(next);
     applyPalette(next);
+    enableTransitions();
 
     try {
       if (next === DEFAULT_PALETTE) {
@@ -71,8 +74,6 @@ export function PaletteProvider({ children }: { children: React.ReactNode }) {
         localStorage.setItem(STORAGE_KEY, next);
       }
     } catch {}
-
-    enableTransitions();
   }, []);
 
   // Sync attribute on mount (covers hydration mismatch edge case)

--- a/src/services/MDXCompiler.ts
+++ b/src/services/MDXCompiler.ts
@@ -27,7 +27,13 @@ export class MDXCompiler extends Context.Service<MDXCompiler>()(
                     rehypeSlug,
                     [
                       rehypePrettyCode,
-                      { keepBackground: false, theme: "synthwave-84" },
+                      {
+                        keepBackground: false,
+                        theme: {
+                          light: "github-light",
+                          dark: "synthwave-84",
+                        },
+                      },
                     ],
                     [
                       rehypeAutolinkHeadings,

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,4 +1,10 @@
-import { Fira_Mono, Josefin_Sans, Roboto_Mono } from "next/font/google";
+import {
+  Fira_Mono,
+  Gabarito,
+  Josefin_Sans,
+  Karla,
+  Roboto_Mono,
+} from "next/font/google";
 
 export const josefin_sans = Josefin_Sans({
   subsets: ["latin"],
@@ -17,4 +23,16 @@ export const fira_mono = Fira_Mono({
   weight: ["400", "500", "700"],
   display: "swap",
   variable: "--font-fira-mono",
+});
+
+export const gabarito = Gabarito({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-gabarito",
+});
+
+export const karla = Karla({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-karla",
 });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -168,7 +168,8 @@
     --muted: light-dark(var(--color-mono-200), var(--color-mono-600));
     --muted-foreground: light-dark(var(--color-mono-600), var(--foreground));
 
-    --accent: light-dark(var(--color-mono-200), var(--color-mono-600));
+    /* Accent: teal-tinted for brand presence on hovers, active states */
+    --accent: light-dark(var(--color-primary-050), var(--color-primary-950));
     --accent-foreground: var(--foreground);
 
     --destructive: var(--color-ui-error);
@@ -188,7 +189,7 @@
 
     --border: light-dark(var(--color-mono-300), var(--color-mono-700));
     --input: light-dark(var(--color-mono-200), var(--color-mono-800));
-    --ring: light-dark(var(--color-primary-400), var(--color-primary-600));
+    --ring: light-dark(var(--color-primary-500), var(--color-primary-500));
 
     --chart-1: light-dark(hsl(12 76% 61%), hsl(220 70% 50%));
     --chart-2: light-dark(hsl(173 58% 39%), hsl(160 60% 45%));
@@ -215,11 +216,13 @@
 }
 
 @utility mosaic-rows {
-  @apply auto-rows-sm md:auto-rows-md lg:auto-rows-lg gap-2;
+  @apply auto-rows-sm md:auto-rows-md lg:auto-rows-lg;
+  gap: var(--mosaic-gap, 0.5rem);
 }
 
 @utility mosaic-columns {
-  @apply grid-cols-8 gap-2 md:grid-cols-16 lg:grid-cols-24;
+  @apply grid-cols-8 md:grid-cols-16 lg:grid-cols-24;
+  gap: var(--mosaic-gap, 0.5rem);
 }
 
 @utility tile-reveal {
@@ -326,5 +329,6 @@
   }
 }
 
+@import "./themes/nerdy.css";
 @import "./mdx.css";
 @import "./mermaid.css";

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -233,7 +233,10 @@
     grid-template-rows 250ms cubic-bezier(0.2, 0, 0, 1),
     opacity 200ms ease,
     visibility 250ms,
-    flex 250ms cubic-bezier(0.2, 0, 0, 1);
+    flex 250ms cubic-bezier(0.2, 0, 0, 1),
+    background-color 300ms ease,
+    border-color 300ms ease,
+    color 300ms ease;
 }
 
 @utility tile-reveal-visible {
@@ -294,7 +297,32 @@
     box-sizing: border-box; /* Opera/IE 8+ */
   }
   body {
-    @apply bg-background text-foreground transition duration-300;
+    @apply bg-background text-foreground;
+  }
+
+  /* Smooth color transitions for light/dark mode toggling.
+   * Applied to all elements so everything shifts together.
+   * Palette-provider disables this temporarily during palette swaps
+   * to avoid intermediate blended states. */
+  *,
+  *::before,
+  *::after {
+    transition:
+      background-color 300ms ease,
+      border-color 300ms ease,
+      color 300ms ease,
+      fill 300ms ease,
+      stroke 300ms ease,
+      box-shadow 300ms ease,
+      outline-color 300ms ease;
+  }
+
+  /* Opt-out for elements that manage their own transitions
+   * (animations, transforms, etc.) */
+  [data-no-color-transition] *,
+  [data-no-color-transition] *::before,
+  [data-no-color-transition] *::after {
+    transition: none;
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -103,6 +103,7 @@
 /* Default theme */
 @layer base {
   :root {
+    /* Palette: Mono */
     --color-mono-050: hsl(210 40% 98%);
     --color-mono-100: hsl(210 40% 96.1%);
     --color-mono-200: hsl(214.3 31.8% 91.4%);
@@ -113,8 +114,9 @@
     --color-mono-700: hsl(215.3 25% 26.7%);
     --color-mono-800: hsl(217.2 32.6% 17.5%);
     --color-mono-900: hsl(222.2 47.4% 11.2%);
-    --color-mono-950: hsl(229 91 9%);
+    --color-mono-950: hsl(229 91% 9%);
 
+    /* Palette: Primary */
     --color-primary-050: hsl(151.8 81% 95.9%);
     --color-primary-100: hsl(149.3 80.4% 90%);
     --color-primary-200: hsl(152.4 76% 80.4%);
@@ -127,6 +129,7 @@
     --color-primary-900: hsl(164.2 85.7% 16.5%);
     --color-primary-950: hsl(166 91% 9%);
 
+    /* Palette: Secondary */
     --color-secondary-050: hsl(48 100% 96.1%);
     --color-secondary-100: hsl(48 96.5% 88.8%);
     --color-secondary-200: hsl(48 96.6% 76.7%);
@@ -139,120 +142,75 @@
     --color-secondary-900: hsl(21.7 77.8% 26.5%);
     --color-secondary-950: hsl(21.7 77.8% 24.5%);
 
-    --color-ui-error: hsl(0 84.2% 60.2%);
-    --color-ui-warning: hsl(45.9 96.7% 64.5%);
-    --color-ui-success: hsl(160.1 84.1% 39.4%);
-    --color-ui-info: hsl(215 16% 47%);
+    /* Semantic UI colors via light-dark() */
+    --color-ui-error: light-dark(hsl(0 84.2% 60.2%), hsl(0 84.2% 65.2%));
+    --color-ui-warning: light-dark(hsl(45.9 96.7% 64.5%), hsl(38 95% 58%));
+    --color-ui-success: light-dark(hsl(160.1 84.1% 39.4%), hsl(142 76% 36%));
+    --color-ui-info: light-dark(hsl(215 16% 47%), hsl(215 86% 70%));
     --color-ui-code: hsl(250 20% 16%);
 
-    /* Functional Colors */
-    --background: var(--color-mono-050);
-    --foreground: var(--color-mono-900);
+    /* Functional Colors via light-dark() */
+    --background: light-dark(var(--color-mono-050), var(--color-mono-900));
+    --foreground: light-dark(var(--color-mono-900), var(--color-mono-100));
 
-    --primary: var(--color-primary-700);
+    --primary: light-dark(var(--color-primary-700), var(--color-primary-500));
     --primary-foreground: var(--background);
 
     --secondary: var(--color-secondary-500);
-    --secondary-foreground: var(--foreground);
+    --secondary-foreground: light-dark(var(--foreground), var(--background));
 
-    --card: var(--color-mono-100);
+    --card: light-dark(var(--color-mono-100), var(--color-mono-800));
     --card-foreground: var(--foreground);
 
-    --popover: var(--color-mono-200);
+    --popover: light-dark(var(--color-mono-200), var(--color-mono-700));
     --popover-foreground: var(--foreground);
 
-    --muted: var(--color-mono-200);
-    --muted-foreground: var(--color-mono-600);
+    --muted: light-dark(var(--color-mono-200), var(--color-mono-600));
+    --muted-foreground: light-dark(var(--color-mono-600), var(--foreground));
 
-    --accent: var(--color-mono-200);
+    --accent: light-dark(var(--color-mono-200), var(--color-mono-600));
     --accent-foreground: var(--foreground);
 
     --destructive: var(--color-ui-error);
     --destructive-foreground: var(--background);
 
     --warning: var(--color-ui-warning);
-    --warning-foreground: var(--foreground);
+    --warning-foreground: light-dark(var(--foreground), var(--background));
 
     --success: var(--color-ui-success);
-    --success-foreground: var(--foreground);
+    --success-foreground: light-dark(var(--foreground), var(--background));
 
     --info: var(--color-ui-info);
-    --info-foreground: var(--background);
+    --info-foreground: light-dark(var(--background), var(--background));
 
     --code: var(--color-ui-code);
     --code-foreground: var(--color-mono-100);
 
-    --border: var(--color-mono-300);
-    --input: var(--color-mono-200);
-    --ring: var(--color-primary-400);
+    --border: light-dark(var(--color-mono-300), var(--color-mono-700));
+    --input: light-dark(var(--color-mono-200), var(--color-mono-800));
+    --ring: light-dark(var(--color-primary-400), var(--color-primary-600));
 
-    --chart-1: hsl(12 76% 61%);
-    --chart-2: hsl(173 58% 39%);
-    --chart-3: hsl(197 37% 24%);
-    --chart-4: hsl(43 74% 66%);
-    --chart-5: hsl(27 87% 67%);
-    --chart-6: hsl(258 62% 64%);
-    --chart-7: hsl(140 45% 42%);
-    --chart-8: hsl(210 65% 55%);
-    --chart-9: hsl(330 70% 58%);
-    --chart-10: hsl(5 70% 52%);
+    --chart-1: light-dark(hsl(12 76% 61%), hsl(220 70% 50%));
+    --chart-2: light-dark(hsl(173 58% 39%), hsl(160 60% 45%));
+    --chart-3: light-dark(hsl(197 37% 24%), hsl(30 80% 55%));
+    --chart-4: light-dark(hsl(43 74% 66%), hsl(280 65% 60%));
+    --chart-5: light-dark(hsl(27 87% 67%), hsl(340 75% 55%));
+    --chart-6: light-dark(hsl(258 62% 64%), hsl(190 70% 45%));
+    --chart-7: light-dark(hsl(140 45% 42%), hsl(90 55% 45%));
+    --chart-8: light-dark(hsl(210 65% 55%), hsl(45 85% 55%));
+    --chart-9: light-dark(hsl(330 70% 58%), hsl(0 75% 60%));
+    --chart-10: light-dark(hsl(5 70% 52%), hsl(260 70% 60%));
+
     --radius: 0.5rem;
   }
 
+  /* color-scheme drives light-dark() resolution */
+  .light {
+    color-scheme: light;
+  }
+
   .dark {
-    --color-ui-error: hsl(0 84.2% 65.2%);
-    --color-ui-warning: hsl(38 95% 58%);
-    --color-ui-success: hsl(142 76% 36%);
-    --color-ui-info: hsl(215 86% 70%);
-
-    /* Functional Colors */
-    --background: var(--color-mono-900);
-    --foreground: var(--color-mono-100);
-
-    --primary: var(--color-primary-500);
-    --primary-foreground: var(--background);
-
-    --secondary: var(--color-secondary-500);
-    --secondary-foreground: var(--background);
-
-    --card: var(--color-mono-800);
-    --card-foreground: var(--foreground);
-
-    --popover: var(--color-mono-700);
-    --popover-foreground: var(--foreground);
-
-    --muted: var(--color-mono-600);
-    --muted-foreground: var(--foreground);
-
-    --accent: var(--color-mono-600);
-    --accent-foreground: var(--foreground);
-
-    --destructive: var(--color-ui-error);
-    --destructive-foreground: var(--background);
-
-    --warning: var(--color-ui-warning);
-    --warning-foreground: var(--background);
-
-    --success: var(--color-ui-success);
-    --success-foreground: var(--background);
-
-    --info: var(--color-ui-info);
-    --info-foreground: var(--background);
-
-    --border: var(--color-mono-700);
-    --input: var(--color-mono-800);
-    --ring: var(--color-primary-600);
-
-    --chart-1: hsl(220 70% 50%);
-    --chart-2: hsl(160 60% 45%);
-    --chart-3: hsl(30 80% 55%);
-    --chart-4: hsl(280 65% 60%);
-    --chart-5: hsl(340 75% 55%);
-    --chart-6: hsl(190 70% 45%);
-    --chart-7: hsl(90 55% 45%);
-    --chart-8: hsl(45 85% 55%);
-    --chart-9: hsl(0 75% 60%);
-    --chart-10: hsl(260 70% 60%);
+    color-scheme: dark;
   }
 }
 
@@ -342,5 +300,3 @@
 
 @import "./mdx.css";
 @import "./mermaid.css";
-
-@custom-variant dark (&:is(.dark *));

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -330,5 +330,6 @@
 }
 
 @import "./themes/nerdy.css";
+@import "./themes/analog.css";
 @import "./mdx.css";
 @import "./mermaid.css";

--- a/src/styles/mdx.css
+++ b/src/styles/mdx.css
@@ -1,3 +1,15 @@
+/* ─── Dual-theme switching (shiki multi-theme) ─────────────────────── */
+/* Shiki stores both themes as CSS variables on each span.
+   We apply the correct one based on the active color scheme. */
+code[data-theme*=" "] span {
+  color: var(--shiki-light) !important;
+}
+
+.dark code[data-theme*=" "] span {
+  color: var(--shiki-dark) !important;
+}
+
+/* ─── Line numbers ─────────────────────────────────────────────────── */
 pre > code {
   counter-reset: line;
 }
@@ -9,36 +21,49 @@ code[data-line-numbers] {
 code[data-line-numbers] > [data-line]::before {
   counter-increment: line;
   content: counter(line);
-  @apply text-accent mr-4 inline-block w-4 text-right;
+  @apply mr-4 inline-block w-4 text-right tabular-nums text-muted-foreground/50;
 }
 
+/* ─── Line spacing ─────────────────────────────────────────────────── */
 pre [data-line]:not([data-highlighted-line]) {
-  @apply border-l-2 border-l-transparent px-2 py-0.5;
+  @apply px-4 py-0.5;
 }
 
+/* ─── Highlighted lines ────────────────────────────────────────────── */
 [data-highlighted-line] {
-  @apply bg-accent/20 border-l-primary border-l-2 px-2 py-0.5;
+  @apply bg-foreground/[0.06] px-4 py-0.5;
 }
 
+.dark [data-highlighted-line] {
+  @apply bg-white/[0.08];
+}
+
+/* ─── Highlighted chars ────────────────────────────────────────────── */
 [data-highlighted-chars] {
-  @apply bg-accent/20 rounded;
+  @apply bg-foreground/[0.06] rounded-sm px-1;
 }
 
+.dark [data-highlighted-chars] {
+  @apply bg-white/10;
+}
+
+/* ─── Semantic line highlights ─────────────────────────────────────── */
 [data-highlighted-line-id="success"] {
-  @apply border-l-success bg-success/20 !text-success;
+  @apply bg-success/10 !text-success;
 }
 [data-highlighted-line-id="warning"] {
-  @apply border-l-warning bg-warning/20 !text-warning;
+  @apply bg-warning/10 !text-warning;
 }
 [data-highlighted-line-id="destructive"] {
-  @apply border-l-destructive bg-destructive/20 !text-destructive;
+  @apply bg-destructive/10 !text-destructive;
 }
 [data-highlighted-line-id="info"] {
-  @apply border-l-info bg-info/20 !text-info;
+  @apply bg-info/10 !text-info;
 }
 
+/* ─── Semantic char highlights ─────────────────────────────────────── */
 [data-chars-id] {
-  @apply border-b-1 px-1 py-0.5 shadow-none;
+  @apply border-b px-1 py-0.5 shadow-none;
 }
 
 [data-chars-id] span {
@@ -46,27 +71,33 @@ pre [data-line]:not([data-highlighted-line]) {
 }
 
 [data-chars-id="success"] {
-  @apply border-b-success bg-success/20 !text-success font-bold;
+  @apply border-b-success bg-success/10 !text-success font-bold;
 }
 [data-chars-id="warning"] {
-  @apply border-b-warning bg-warning/20 !text-warning font-bold;
+  @apply border-b-warning bg-warning/10 !text-warning font-bold;
 }
 [data-chars-id="destructive"] {
-  @apply border-b-destructive bg-destructive/20 !text-destructive font-bold;
+  @apply border-b-destructive bg-destructive/10 !text-destructive font-bold;
 }
 [data-chars-id="info"] {
-  @apply border-b-info bg-info/20 !text-info font-bold;
+  @apply border-b-info bg-info/10 !text-info font-bold;
 }
 
+/* ─── Title bar (figcaption) ───────────────────────────────────────── */
 [data-rehype-pretty-code-title] {
-  @apply bg-accent text-accent-foreground rounded-t-lg px-3 py-2 text-sm font-semibold;
+  @apply bg-muted/50 text-muted-foreground border-b border-border/50 px-4 py-2 text-xs font-medium tracking-wide;
 }
 
-figure[data-rehype-pretty-code-figure]:has(> [data-rehype-pretty-code-title])
-  pre {
-  @apply !rounded-t-none;
+/* ─── Code figure container ────────────────────────────────────────── */
+figure[data-rehype-pretty-code-figure] {
+  @apply my-6 overflow-hidden rounded-md border border-border;
 }
 
+figure[data-rehype-pretty-code-figure] pre {
+  @apply !mb-0 !rounded-none !border-0 pt-3;
+}
+
+/* ─── Anchor links ─────────────────────────────────────────────────── */
 .subheading-anchor {
   opacity: 0;
   transition: opacity 0.2s;

--- a/src/styles/mermaid.css
+++ b/src/styles/mermaid.css
@@ -1,3 +1,18 @@
 div.mermaid {
-  @apply bg-code text-code-foreground my-4 flex justify-center overflow-x-auto rounded-md p-3;
+  @apply my-6 flex justify-center overflow-x-auto rounded-md border border-border bg-muted/50 p-4 text-foreground;
+}
+
+.dark div.mermaid {
+  @apply bg-muted/30;
+}
+
+/* Override mermaid SVG background to be transparent (we control bg via container) */
+div.mermaid svg {
+  background: transparent !important;
+}
+
+/* In dark mode, invert the diagram for legibility since mermaid "neutral" theme
+   renders dark text on light nodes. The hue-rotate preserves color meaning. */
+.dark div.mermaid svg {
+  filter: invert(0.88) hue-rotate(180deg);
 }

--- a/src/styles/themes/analog.css
+++ b/src/styles/themes/analog.css
@@ -1,0 +1,271 @@
+/* Analog Theme: The Field Notebook
+ *
+ * Warm sepia-tinted neutrals, burnt sienna primary, deep indigo secondary.
+ * Light mode is native (cream paper, ink, sunlit workspace).
+ * Dark mode becomes "writing at night" (warm amber undertones, lamplight).
+ * Borders soften or disappear; depth through warmth shifts.
+ * Grid breathes more (wider gap), corners round further (organic forms).
+ * Typography swaps: Gabarito for display (specimen-label energy),
+ * Karla for body (pencil-on-graph-paper warmth).
+ *
+ * Structural divergence from standard:
+ * - Larger radius (12px) — organic, hand-drawn feeling
+ * - Dual proportional families (Gabarito display + Karla body)
+ * - Wider grid gap (0.75rem) — breathing room, white space as material
+ * - Softer borders (hairline, warm-tinted, or absent)
+ * - Warmer shadows (subtle, warm-toned, like paper edge)
+ * - Lowercase headings with generous letter-spacing (field label style)
+ * - Custom selection in pencil-yellow
+ * - Visible dot-grid background texture on page surface
+ */
+
+:root[data-theme="analog"] {
+  /* === STRUCTURAL TOKENS === */
+
+  /* Organic corners: hand-drawn shapes aren't angular */
+  --radius: 12px;
+
+  /* Typography swap: warm proportional families.
+   * Gabarito for display/headings (specimen-label, felt-tip warmth).
+   * Karla for body (humanist sans, pencil-on-grid-paper). */
+  --font-serif: var(--font-gabarito);
+  --font-sans: var(--font-karla);
+
+  /* Breathing grid: field notebooks have generous margins */
+  --mosaic-gap: 0.75rem;
+
+  /* === COLOR PALETTE === */
+
+  /* Palette: Mono (warm sepia/cream neutrals) */
+  --color-mono-050: hsl(40 30% 97%);
+  --color-mono-100: hsl(38 28% 93%);
+  --color-mono-200: hsl(36 22% 85%);
+  --color-mono-300: hsl(34 18% 72%);
+  --color-mono-400: hsl(32 14% 55%);
+  --color-mono-500: hsl(30 12% 42%);
+  --color-mono-600: hsl(28 14% 32%);
+  --color-mono-700: hsl(26 18% 24%);
+  --color-mono-800: hsl(24 22% 16%);
+  --color-mono-900: hsl(22 26% 11%);
+  --color-mono-950: hsl(20 30% 7%);
+
+  /* Palette: Primary (burnt sienna / terracotta) */
+  --color-primary-050: hsl(18 60% 96%);
+  --color-primary-100: hsl(16 55% 90%);
+  --color-primary-200: hsl(14 50% 78%);
+  --color-primary-300: hsl(12 48% 64%);
+  --color-primary-400: hsl(10 52% 52%);
+  --color-primary-500: hsl(8 58% 44%);
+  --color-primary-600: hsl(6 60% 36%);
+  --color-primary-700: hsl(4 55% 30%);
+  --color-primary-800: hsl(2 48% 24%);
+  --color-primary-900: hsl(0 42% 18%);
+  --color-primary-950: hsl(358 38% 12%);
+
+  /* Palette: Secondary (deep indigo / ink) */
+  --color-secondary-050: hsl(230 35% 96%);
+  --color-secondary-100: hsl(228 32% 90%);
+  --color-secondary-200: hsl(226 28% 78%);
+  --color-secondary-300: hsl(224 26% 64%);
+  --color-secondary-400: hsl(222 30% 52%);
+  --color-secondary-500: hsl(220 38% 42%);
+  --color-secondary-600: hsl(218 42% 34%);
+  --color-secondary-700: hsl(216 40% 28%);
+  --color-secondary-800: hsl(214 38% 22%);
+  --color-secondary-900: hsl(212 35% 16%);
+  --color-secondary-950: hsl(210 32% 10%);
+
+  /* === SEMANTIC UI COLORS === */
+
+  --color-ui-error: light-dark(hsl(4 65% 48%), hsl(4 58% 58%));
+  --color-ui-warning: light-dark(hsl(36 80% 48%), hsl(38 72% 56%));
+  --color-ui-success: light-dark(hsl(148 45% 38%), hsl(150 40% 48%));
+  --color-ui-info: light-dark(hsl(220 38% 42%), hsl(222 42% 62%));
+  --color-ui-code: hsl(24 22% 16%);
+
+  /* === FUNCTIONAL COLORS === */
+
+  --background: light-dark(var(--color-mono-050), var(--color-mono-900));
+  --foreground: light-dark(var(--color-mono-900), var(--color-mono-100));
+
+  --primary: light-dark(var(--color-primary-600), var(--color-primary-400));
+  --primary-foreground: light-dark(
+    var(--color-mono-050),
+    var(--color-mono-950)
+  );
+
+  --secondary: light-dark(
+    var(--color-secondary-500),
+    var(--color-secondary-400)
+  );
+  --secondary-foreground: light-dark(
+    var(--color-mono-050),
+    var(--color-mono-100)
+  );
+
+  /* Cards float slightly above the warm surface */
+  --card: light-dark(var(--color-mono-100), var(--color-mono-800));
+  --card-foreground: var(--foreground);
+
+  --popover: light-dark(var(--color-mono-100), var(--color-mono-700));
+  --popover-foreground: var(--foreground);
+
+  --muted: light-dark(var(--color-mono-200), var(--color-mono-700));
+  --muted-foreground: light-dark(var(--color-mono-500), var(--color-mono-400));
+
+  /* Accent: warm primary tint for hovers and interactive states */
+  --accent: light-dark(var(--color-primary-050), var(--color-primary-950));
+  --accent-foreground: var(--foreground);
+
+  --destructive: var(--color-ui-error);
+  --destructive-foreground: light-dark(
+    var(--color-mono-050),
+    var(--color-mono-950)
+  );
+
+  --warning: var(--color-ui-warning);
+  --warning-foreground: light-dark(
+    var(--color-mono-950),
+    var(--color-mono-950)
+  );
+
+  --success: var(--color-ui-success);
+  --success-foreground: light-dark(
+    var(--color-mono-050),
+    var(--color-mono-950)
+  );
+
+  --info: var(--color-ui-info);
+  --info-foreground: light-dark(var(--color-mono-050), var(--color-mono-050));
+
+  /* Code: warm parchment tone, ink-on-paper */
+  --code: light-dark(var(--color-mono-200), var(--color-mono-800));
+  --code-foreground: light-dark(var(--color-mono-800), var(--color-mono-200));
+
+  /* Borders: warm, subtle, like pencil lines on paper */
+  --border: light-dark(var(--color-mono-200), var(--color-mono-700));
+  --input: light-dark(var(--color-mono-200), var(--color-mono-700));
+  --ring: light-dark(var(--color-primary-400), var(--color-primary-500));
+
+  /* === CHART COLORS (naturalist / earth-toned) === */
+
+  --chart-1: light-dark(hsl(8 58% 44%), hsl(10 52% 56%));
+  --chart-2: light-dark(hsl(148 45% 38%), hsl(150 40% 50%));
+  --chart-3: light-dark(hsl(220 38% 42%), hsl(222 42% 58%));
+  --chart-4: light-dark(hsl(36 65% 48%), hsl(38 60% 56%));
+  --chart-5: light-dark(hsl(280 30% 45%), hsl(282 28% 58%));
+  --chart-6: light-dark(hsl(170 40% 36%), hsl(172 38% 48%));
+  --chart-7: light-dark(hsl(50 55% 42%), hsl(52 50% 52%));
+  --chart-8: light-dark(hsl(340 40% 45%), hsl(342 38% 58%));
+  --chart-9: light-dark(hsl(100 35% 38%), hsl(102 32% 48%));
+  --chart-10: light-dark(hsl(25 60% 42%), hsl(27 55% 54%));
+}
+
+/* === STRUCTURAL OVERRIDES (require selectors beyond :root) === */
+
+/* Typography: field notebook style — lowercase headings, generous spacing */
+[data-theme="analog"] h1,
+[data-theme="analog"] h2,
+[data-theme="analog"] h3,
+[data-theme="analog"] h4,
+[data-theme="analog"] h5,
+[data-theme="analog"] h6 {
+  font-family: var(--font-gabarito), system-ui, sans-serif;
+  text-transform: none;
+  letter-spacing: -0.01em;
+  font-weight: 700;
+}
+
+/* Body text uses Karla for warmth */
+[data-theme="analog"] p,
+[data-theme="analog"] li,
+[data-theme="analog"] td,
+[data-theme="analog"] th,
+[data-theme="analog"] label,
+[data-theme="analog"] span,
+[data-theme="analog"] div {
+  font-family: var(--font-karla), system-ui, sans-serif;
+}
+
+/* Code stays monospace (Fira Mono) — the contrast is intentional */
+[data-theme="analog"] code,
+[data-theme="analog"] pre,
+[data-theme="analog"] [data-slot="code"] {
+  font-family: var(--font-fira-mono), monospace;
+}
+
+/* Card labels/metadata: warm proportional, slightly spaced */
+[data-theme="analog"] [data-slot="card-header"] {
+  font-family: var(--font-karla), system-ui, sans-serif;
+  letter-spacing: 0.02em;
+}
+
+/* Badges/tags: proportional font, no small-caps (too cramped at 12px) */
+[data-theme="analog"] [data-slot="badge"] {
+  font-family: var(--font-karla), system-ui, sans-serif;
+  letter-spacing: 0.01em;
+  font-variant: normal;
+  text-transform: lowercase;
+}
+
+/* Softer card treatment: warm shadow instead of none */
+[data-theme="analog"] [data-slot="card"],
+[data-theme="analog"] .bg-card {
+  box-shadow:
+    0 1px 3px hsl(30 20% 30% / 0.06),
+    0 1px 2px hsl(30 20% 30% / 0.04);
+  border: 1px solid light-dark(hsl(36 22% 85% / 0.8), hsl(26 18% 24% / 0.6));
+}
+
+/* Selection: pencil-yellow highlight */
+[data-theme="analog"] ::selection {
+  background: hsl(48 80% 60% / 0.35);
+  color: inherit;
+}
+
+/* Scrollbar: warm, muted */
+[data-theme="analog"] {
+  scrollbar-color: hsl(30 20% 50% / 0.3) transparent;
+  scrollbar-width: thin;
+}
+
+[data-theme="analog"] ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+[data-theme="analog"] ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-theme="analog"] ::-webkit-scrollbar-thumb {
+  background: hsl(30 20% 50% / 0.3);
+  border-radius: 12px;
+}
+
+[data-theme="analog"] ::-webkit-scrollbar-thumb:hover {
+  background: hsl(30 20% 50% / 0.5);
+}
+
+/* Dot-grid background texture: graph paper feel on the page surface */
+[data-theme="analog"] body {
+  background-image: radial-gradient(
+    circle,
+    light-dark(hsl(30 15% 70% / 0.2), hsl(30 15% 40% / 0.08)) 1px,
+    transparent 1px
+  );
+  background-size: 24px 24px;
+}
+
+/* Nav tiles: slightly more rounded, warmer hover */
+[data-theme="analog"] nav button,
+[data-theme="analog"] nav a {
+  border-radius: 12px;
+}
+
+/* Inline code: warm paper pill */
+[data-theme="analog"] :not(pre) > code {
+  background: light-dark(hsl(36 22% 85% / 0.5), hsl(24 22% 20% / 0.5));
+  border-radius: 6px;
+  padding: 0.1em 0.4em;
+}

--- a/src/styles/themes/nerdy.css
+++ b/src/styles/themes/nerdy.css
@@ -1,0 +1,222 @@
+/* Nerdy Theme: Terminal Phosphor
+ *
+ * Green-tinted neutrals, phosphor green primary, violet secondary.
+ * Dark mode is the native state (tight tonal range, flat terminal feel).
+ * Light mode is "paper terminal" (warm cream, aged dot-matrix output).
+ * Borders are structural and always visible (terminal window frames).
+ * Code blocks blend with the surface (everything is already code).
+ * Chart colors are ANSI-inspired.
+ *
+ * Structural divergence from standard:
+ * - Sharp corners (radius: 2px)
+ * - Single monospace family (Fira Mono everywhere)
+ * - Denser grid gap
+ * - No shadows (borders only)
+ * - Wider letter-spacing on labels (console output feel)
+ * - Custom selection + scrollbar colors
+ */
+
+:root[data-theme="nerdy"] {
+  /* === STRUCTURAL TOKENS === */
+
+  /* Sharp corners: terminals don't round */
+  --radius: 2px;
+
+  /* Single monospace family: Fira Mono for everything.
+   * Hierarchy through weight and size only, like man pages. */
+  --font-serif: var(--font-fira-mono);
+  --font-sans: var(--font-fira-mono);
+
+  /* Denser grid: terminal panes sit tight */
+  --mosaic-gap: 0.25rem;
+
+  /* === COLOR PALETTE === */
+
+  /* Palette: Mono (green-undertinted neutrals) */
+  --color-mono-050: hsl(80 20% 97%);
+  --color-mono-100: hsl(75 15% 93%);
+  --color-mono-200: hsl(70 10% 84%);
+  --color-mono-300: hsl(75 8% 70%);
+  --color-mono-400: hsl(80 6% 52%);
+  --color-mono-500: hsl(85 7% 38%);
+  --color-mono-600: hsl(90 9% 28%);
+  --color-mono-700: hsl(95 12% 20%);
+  --color-mono-800: hsl(100 14% 14%);
+  --color-mono-900: hsl(105 18% 9%);
+  --color-mono-950: hsl(110 22% 5%);
+
+  /* Palette: Primary (phosphor green) */
+  --color-primary-050: hsl(130 40% 95%);
+  --color-primary-100: hsl(132 42% 88%);
+  --color-primary-200: hsl(134 40% 76%);
+  --color-primary-300: hsl(136 38% 62%);
+  --color-primary-400: hsl(138 42% 48%);
+  --color-primary-500: hsl(140 55% 38%);
+  --color-primary-600: hsl(142 60% 30%);
+  --color-primary-700: hsl(144 58% 24%);
+  --color-primary-800: hsl(146 52% 18%);
+  --color-primary-900: hsl(148 48% 13%);
+  --color-primary-950: hsl(150 45% 8%);
+
+  /* Palette: Secondary (violet/purple) */
+  --color-secondary-050: hsl(270 40% 96%);
+  --color-secondary-100: hsl(272 38% 90%);
+  --color-secondary-200: hsl(274 35% 80%);
+  --color-secondary-300: hsl(276 32% 68%);
+  --color-secondary-400: hsl(278 35% 58%);
+  --color-secondary-500: hsl(280 40% 48%);
+  --color-secondary-600: hsl(282 42% 40%);
+  --color-secondary-700: hsl(284 40% 32%);
+  --color-secondary-800: hsl(286 38% 24%);
+  --color-secondary-900: hsl(288 35% 18%);
+  --color-secondary-950: hsl(290 32% 12%);
+
+  /* === SEMANTIC UI COLORS === */
+
+  --color-ui-error: light-dark(hsl(0 70% 55%), hsl(0 65% 62%));
+  --color-ui-warning: light-dark(hsl(40 85% 50%), hsl(40 80% 58%));
+  --color-ui-success: light-dark(hsl(140 55% 38%), hsl(140 50% 45%));
+  --color-ui-info: light-dark(hsl(210 50% 45%), hsl(210 55% 65%));
+  --color-ui-code: hsl(105 18% 9%);
+
+  /* === FUNCTIONAL COLORS === */
+
+  --background: light-dark(var(--color-mono-050), var(--color-mono-950));
+  --foreground: light-dark(var(--color-mono-900), var(--color-mono-100));
+
+  --primary: light-dark(var(--color-primary-600), var(--color-primary-400));
+  --primary-foreground: light-dark(
+    var(--color-mono-050),
+    var(--color-mono-950)
+  );
+
+  --secondary: light-dark(
+    var(--color-secondary-500),
+    var(--color-secondary-400)
+  );
+  --secondary-foreground: light-dark(
+    var(--color-mono-050),
+    var(--color-mono-950)
+  );
+
+  /* Dark: tighter range (950 → 900 → 800 instead of 900 → 800 → 700) */
+  --card: light-dark(var(--color-mono-100), var(--color-mono-900));
+  --card-foreground: var(--foreground);
+
+  --popover: light-dark(var(--color-mono-200), var(--color-mono-800));
+  --popover-foreground: var(--foreground);
+
+  --muted: light-dark(var(--color-mono-200), var(--color-mono-800));
+  --muted-foreground: light-dark(var(--color-mono-500), var(--color-mono-400));
+
+  --accent: light-dark(var(--color-mono-200), var(--color-mono-800));
+  --accent-foreground: var(--foreground);
+
+  --destructive: var(--color-ui-error);
+  --destructive-foreground: light-dark(
+    var(--color-mono-050),
+    var(--color-mono-950)
+  );
+
+  --warning: var(--color-ui-warning);
+  --warning-foreground: light-dark(
+    var(--color-mono-950),
+    var(--color-mono-950)
+  );
+
+  --success: var(--color-ui-success);
+  --success-foreground: light-dark(
+    var(--color-mono-050),
+    var(--color-mono-950)
+  );
+
+  --info: var(--color-ui-info);
+  --info-foreground: light-dark(var(--color-mono-050), var(--color-mono-950));
+
+  /* Code: one step deeper than card (subtle, everything is already "code") */
+  --code: light-dark(var(--color-mono-200), var(--color-mono-900));
+  --code-foreground: light-dark(var(--color-mono-800), var(--color-mono-200));
+
+  /* Borders: brighter, structural, terminal window frame feel */
+  --border: light-dark(var(--color-mono-300), var(--color-mono-600));
+  --input: light-dark(var(--color-mono-200), var(--color-mono-800));
+  --ring: light-dark(var(--color-primary-400), var(--color-primary-500));
+
+  /* === CHART COLORS (ANSI-inspired) === */
+
+  --chart-1: light-dark(hsl(0 65% 50%), hsl(0 60% 60%));
+  --chart-2: light-dark(hsl(140 55% 35%), hsl(140 50% 50%));
+  --chart-3: light-dark(hsl(45 80% 45%), hsl(45 75% 55%));
+  --chart-4: light-dark(hsl(220 55% 50%), hsl(220 50% 62%));
+  --chart-5: light-dark(hsl(300 40% 45%), hsl(300 38% 60%));
+  --chart-6: light-dark(hsl(180 55% 35%), hsl(180 50% 50%));
+  --chart-7: light-dark(hsl(30 70% 45%), hsl(30 65% 55%));
+  --chart-8: light-dark(hsl(260 45% 50%), hsl(260 42% 62%));
+  --chart-9: light-dark(hsl(80 50% 38%), hsl(80 45% 50%));
+  --chart-10: light-dark(hsl(340 55% 48%), hsl(340 50% 60%));
+}
+
+/* === STRUCTURAL OVERRIDES (require selectors beyond :root) === */
+
+/* Force borders on all tiles and cards: terminal panes always have frames */
+[data-theme="nerdy"] [data-slot="card"],
+[data-theme="nerdy"] .bg-card {
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+/* Kill all shadows: terminals are flat */
+[data-theme="nerdy"] *,
+[data-theme="nerdy"] *::before,
+[data-theme="nerdy"] *::after {
+  --tw-shadow: 0 0 #0000 !important;
+  --tw-shadow-colored: 0 0 #0000 !important;
+}
+
+/* Letter-spacing: console output feel on headings and labels */
+[data-theme="nerdy"] h1,
+[data-theme="nerdy"] h2,
+[data-theme="nerdy"] h3,
+[data-theme="nerdy"] h4,
+[data-theme="nerdy"] h5,
+[data-theme="nerdy"] h6 {
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+/* Meta/label text gets wider spacing like terminal status lines */
+[data-theme="nerdy"] [data-slot="card-header"],
+[data-theme="nerdy"] [data-slot="badge"] {
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+/* Selection: phosphor green */
+[data-theme="nerdy"] ::selection {
+  background: hsl(140 55% 38% / 0.3);
+  color: inherit;
+}
+
+/* Scrollbar: thin, terminal-colored */
+[data-theme="nerdy"] {
+  scrollbar-color: hsl(140 55% 38% / 0.4) transparent;
+  scrollbar-width: thin;
+}
+
+[data-theme="nerdy"] ::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+[data-theme="nerdy"] ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-theme="nerdy"] ::-webkit-scrollbar-thumb {
+  background: hsl(140 55% 38% / 0.4);
+  border-radius: 2px;
+}
+
+[data-theme="nerdy"] ::-webkit-scrollbar-thumb:hover {
+  background: hsl(140 55% 38% / 0.6);
+}


### PR DESCRIPTION
## Goals/Scope

Adding Multi-theme support like I had in the last version, but will update to use some newer css tricks like `light-dark()` and seperate dark mode from the theme.

Added two new themes plus some refinements on the current:
- Standard (Clean Slate) <- Cool blue-grey neutrals with teal primary and warm amber accents. A balanced, professional default.
- Nerdy (Terminal Phosphor) <- Green-tinted neutrals with phosphor green primary and violet secondary. Monospace everything, sharp corners, no shadows — pure terminal aesthetic.
- Analog (Field Notebook) <- Warm sepia neutrals with burnt sienna primary and deep indigo secondary. Rounded corners, soft shadows, and breathing whitespace — like a sun-worn sketchbook.

While I was add it I also tidied up the home page tiles a bit so they flow better together