### PR TITLE
fix: bump timeout for pdf

### DIFF
--- a/src/app/cv/[variant]/pdf/route.ts
+++ b/src/app/cv/[variant]/pdf/route.ts
@@ -11,6 +11,7 @@ type CvVariantPdfRouteProps = {
 };
 
 export const dynamic = "force-dynamic";
+export const maxDuration = 60;
 export const runtime = "nodejs";
 
 const LETTER_WIDTH_PX = 816;
@@ -78,8 +79,10 @@ export async function GET(
     });
     const origin = new URL(request.url).origin;
     await page.goto(`${origin}/cv/${variant.slug}`, {
-      waitUntil: "networkidle0",
+      timeout: 15_000,
+      waitUntil: "domcontentloaded",
     });
+    await page.evaluate(() => document.fonts.ready);
 
     const documentHeight = await page.evaluate(() =>
       Math.max(


### PR DESCRIPTION
## Goals/Scope

- Increase the timeout used for PDF-related operations to prevent premature failures/timeouts.